### PR TITLE
Terraform Deploy

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -1,0 +1,32 @@
+name: Terraform Deploy
+
+on:
+    pull_request:
+      branches:
+        - main
+        
+env: 
+    TERRAFORM_VERSION: "1.10.2"
+
+jobs:
+    deploy_dev:
+        runs-on: ubuntu-latest 
+        steps: 
+            - name: checkout
+              uses: actions/checkout@v4
+            
+            - name: install terraform 
+              uses: hashicorp/setup-terraform@v3
+              with:
+                terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                aws-region: us-east-2
+                
+            - name: terraform apply
+              run: | 
+                terraform apply --auto-approve

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -28,6 +28,10 @@ jobs:
                 aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                 aws-region: us-east-2
                 
+            - name: terraform init
+              run: | 
+                terraform init 
+                
             - name: terraform apply
               run: | 
                 terraform apply --auto-approve

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -10,7 +10,8 @@ env:
 
 jobs:
     deploy_dev:
-        runs-on: ubuntu-latest 
+        runs-on: ubuntu-latest
+        environment: dev 
         steps: 
             - name: checkout
               uses: actions/checkout@v4


### PR DESCRIPTION
For terraform to deploy to AWS, it requires AWS credential to be able to deploy AWS resources through terraform. 
This pull request is out to setup cicd for terraform to AWS.